### PR TITLE
Set min max dates on create period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+# 0.7.0
+- Add possiblity to check if period is in min/max range
+
 # 0.6.0
--- Add new method to get all dates in period
+- Add new method to get all dates in period
 
 # 0.5.0
 

--- a/source/period.js
+++ b/source/period.js
@@ -258,13 +258,29 @@ Unit.prototype.getShortStringForTime = function (time) {
  * @param {string} periodMode Describes which time unit the period uses
  * @param {date|moment} start The date on which the period starts
  * @param {date|moment} end The date on which the period ends
+ * @param {date|moment} minDate The date on which the period must start at minimum
+ * @param {date|moment} maxDate The date on which the period must end at a maximum
  * @constructor
  */
-Period = function (periodMode, start, end) {
+Period = function (periodMode, start, end, minDate, maxDate) {
     //TODO:Make variables private and expose setters and getters
     this.periodMode = periodMode;
     this.start = moment.utc(start);
     this.end = moment.utc(end);
+
+    if (typeof minDate !== "undefined") {
+        var min = moment.utc(minDate);
+        if (this.start.isBefore(min)) {
+            this.start = min;
+        }
+    }
+
+    if (typeof maxDate !== "undefined") {
+        var max = moment.utc(maxDate);
+        if (this.end.isAfter(max)) {
+            this.end = max;
+        }
+    }
 
     expandRangeToCompletePeriods(this.start, this.end, this.periodMode);
 
@@ -670,10 +686,12 @@ api = {};
  * @param {string} periodMode PeriodMode of this instance
  * @param {date|moment} start The date on which the period starts
  * @param {date|moment} end The date on which the period ends
+ * @param {date|moment} minDate The date on which the period must start at minimum
+ * @param {date|moment} maxDate The date on which the period must end at a maximum
  * @returns {Period}
  */
-api.createPeriod = function (periodMode, start, end) {
-    return new Period(periodMode, start, end);
+api.createPeriod = function (periodMode, start, end, minDate, maxDate) {
+    return new Period(periodMode, start, end, minDate, maxDate);
 };
 
 /**


### PR DESCRIPTION
On period creation a min and max range may be provided .

If the start or end date that are provided to create the period lay outside of the provided min/may range, the constructor will take the mix/max date instead